### PR TITLE
Fix Shape Mismatch Bug When Setting Batch Size to 1

### DIFF
--- a/depth/train.py
+++ b/depth/train.py
@@ -225,7 +225,7 @@ def train(train_loader, model, criterion_d, log_txt, optimizer, device, epoch, a
         preds = model(input_RGB, class_ids=batch['class_id'])
 
         optimizer.zero_grad()
-        loss_d = criterion_d(preds['pred_d'].squeeze(), depth_gt)
+        loss_d = criterion_d(preds['pred_d'].squeeze(dim=0), depth_gt)
 
         if args.rank == 0:
             depth_loss.update(loss_d.item(), input_RGB.size(0))


### PR DESCRIPTION
I recently came across a minor bug related to shape mismatch when setting the `batch_size = 1` (using about 22G VRAM in this case). The issue is caused by an extra squeezing of the `batch_size` dimension. I made a small tweak that fixed the problem for me, and I hope it can help others facing the same issue. By the way, I just wanted to say thanks for the awesome work you've done – it's really impressive!

I hope this helps. Thanks!